### PR TITLE
Fix param default value on helper

### DIFF
--- a/dev/common/helper.js
+++ b/dev/common/helper.js
@@ -27,7 +27,7 @@ module.exports = {
     return resultPath;
   },
 
-  replaceUrlParamsWithValues: (url, paramValues) => {
+  replaceUrlParamsWithValues: (url, paramValues = {}) => {
     const paramKeys = Object.keys(paramValues);
     let newurl = url;
     for (let i = 0; i < paramKeys.length; i += 1) {


### PR DESCRIPTION
`Object.keys(paramValues)` throws exception if paramValues is not defined. 